### PR TITLE
Lockscreen PIN quick unlock [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -7431,6 +7431,12 @@ public final class Settings {
         public static final String ASSIST_DISCLOSURE_ENABLED = "assist_disclosure_enabled";
 
         /**
+         * Whether to use the custom quick unlock screen control
+         * @hide
+         */
+        public static final String LOCKSCREEN_QUICK_UNLOCK_CONTROL = "lockscreen_quick_unlock_control";
+
+        /**
          * Names of the service components that the current user has explicitly allowed to
          * see all of the user's notifications, separated by ':'.
          *
@@ -7899,7 +7905,8 @@ public final class Settings {
             STATUS_BAR_BATTERY_STYLE_TILE,
             DOZE_ENABLED,
             DOZE_PULSE_ON_PICK_UP,
-            DOZE_PULSE_ON_DOUBLE_TAP
+            DOZE_PULSE_ON_DOUBLE_TAP,
+            LOCKSCREEN_QUICK_UNLOCK_CONTROL
         };
 
         /**

--- a/packages/Keyguard/src/com/android/keyguard/KeyguardSimPinView.java
+++ b/packages/Keyguard/src/com/android/keyguard/KeyguardSimPinView.java
@@ -137,6 +137,12 @@ public class KeyguardSimPinView extends KeyguardPinBasedInputView {
         return R.id.simPinEntry;
     }
 
+    // Listener callback.
+    @Override
+    public void onTextChanged() {
+        // SIM PIN doesn't use quick unlock
+    }
+
     @Override
     protected void onFinishInflate() {
         super.onFinishInflate();

--- a/packages/Keyguard/src/com/android/keyguard/PasswordTextView.java
+++ b/packages/Keyguard/src/com/android/keyguard/PasswordTextView.java
@@ -100,6 +100,21 @@ public class PasswordTextView extends View {
         void onUserActivity();
     }
 
+    public interface OnTextChangedListener {
+        void onTextChanged();
+    }
+    private OnTextChangedListener mOnTextChangedListener = null;
+
+    public void setOnTextChangedListener(OnTextChangedListener onTextChangedListener) {
+        mOnTextChangedListener = onTextChangedListener;
+    }
+
+    private void textChanged() {
+        if (mOnTextChangedListener != null) {
+            mOnTextChangedListener.onTextChanged();
+        }
+    }
+
     public PasswordTextView(Context context) {
         this(context, null);
     }
@@ -225,6 +240,7 @@ public class PasswordTextView extends View {
                 previousState.swapToDotWhenAppearFinished();
             }
         }
+        textChanged();
         userActivity();
         sendAccessibilityEventTypeViewTextChanged(textbefore, textbefore.length(), 0, 1);
     }
@@ -248,6 +264,7 @@ public class PasswordTextView extends View {
             CharState charState = mTextChars.get(length - 1);
             charState.startRemoveAnimation(0, 0);
         }
+        textChanged();
         userActivity();
         sendAccessibilityEventTypeViewTextChanged(textbefore, textbefore.length() - 1, 1, 0);
     }
@@ -297,6 +314,7 @@ public class PasswordTextView extends View {
         if (!animated) {
             mTextChars.clear();
         }
+        textChanged();
         if (announce) {
             sendAccessibilityEventTypeViewTextChanged(textbefore, 0, textbefore.length(), 0);
         }


### PR DESCRIPTION
old way does not work anymore exactly like before. So adapt the idea to new LP code

Thankd DVTonder for the basic idea prior LP

PS:
- do PIN view correctly

Initial LP implementation by Lars Greiss, ported and adapted to MM by Yank555.lu

Lockscreen PIN quick unlock: Limit quick unlock to a length 4 to avoid lockout

Disabled by default / only for PIN (not password, pointless)