### PR TITLE
Adjust QS battery tile padding from 2dp to 0dp

### DIFF
--- a/packages/SystemUI/res/values/dimens.xml
+++ b/packages/SystemUI/res/values/dimens.xml
@@ -204,7 +204,7 @@
     <dimen name="qs_detail_margin_top">28dp</dimen>
     <dimen name="qs_data_usage_text_size">14sp</dimen>
     <dimen name="qs_data_usage_usage_text_size">36sp</dimen>
-    <dimen name="qs_battery_padding">2dp</dimen>
+    <dimen name="qs_battery_padding">0dp</dimen>
     <dimen name="qs_detail_items_padding_top">4dp</dimen>
 
     <dimen name="segmented_button_spacing">0dp</dimen>


### PR DESCRIPTION
We're currently syncing the battery from the statusbar to the QS tile. While
that works, the size is just not the same as it was on stock. This adjustment
brings it closer to stock until we can come up with a more permanent fix.

See image - https://i.imgur.com/47pytg0.png

Change-Id: I93b99c84c9124a6ad157e8285263e55cf24d7c1a