### PR TITLE
fingerprintd : Fix stopAuthentication

### DIFF
--- a/services/core/java/com/android/server/fingerprint/AuthenticationClient.java
+++ b/services/core/java/com/android/server/fingerprint/AuthenticationClient.java
@@ -82,7 +82,6 @@ public abstract class AuthenticationClient extends ClientMonitor {
             // allow system-defined limit of number of attempts before giving up
             boolean inLockoutMode =  handleFailedAttempt();
             // send lockout event in case driver doesn't enforce it.
-            stop(true);
             if (inLockoutMode) {
                 try {
                     Slog.w(TAG, "Forcing lockout (fp driver code should do this!)");


### PR DESCRIPTION
Bug :
When finger is not authenticated / doesn't recognise , it doesn't allow to unlock the phone via fp anymore , it only unlocks via pattern .

Log : 
04-27 15:31:19.855   953   953 V fingerprintd: stopAuthentication()
04-27 15:31:19.855   953   953 D fpc_fingerprint_hal: fpc_cancel
04-27 15:31:19.855   953   953 I fpc_fingerprint_hal: fpc_worker_set_state_locked worker_state_t = -1
04-27 15:31:19.878   953  3326 D fpc_fingerprint_hal: fpc_wait_finger_up interrupted
04-27 15:31:19.878   953  3326 E fpc_fingerprint_hal: capture_single_image failed -4
04-27 15:31:19.880   953  3326 E fpc_fingerprint_hal: do_identify failed -4
04-27 15:31:19.880   953  3326 D fpc_fingerprint_hal: workerFunction STATE_IDLE
04-27 15:31:19.880   953  3326 D fpc_fingerprint_hal: fpc_wait_finger_up
04-27 15:31:19.881  1662  1662 W FingerprintService: client com.android.systemui is no longer authenticating