### PR TITLE
Set default screenshot delay to 600ms (1/2)

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/ScreenshotTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/ScreenshotTile.java
@@ -177,7 +177,7 @@ public class ScreenshotTile extends QSTile<QSTile.BooleanState> {
 
     private void checkSettings() {
         mScreenshotDelay = Settings.System.getInt(mContext.getContentResolver(),
-                Settings.System.SCREENSHOT_DELAY, 100);
+                Settings.System.SCREENSHOT_DELAY, 600);
     }
 }
 

--- a/services/core/java/com/android/server/policy/GlobalActions.java
+++ b/services/core/java/com/android/server/policy/GlobalActions.java
@@ -1714,6 +1714,6 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
 
     private void checkSettings() {
         mScreenshotDelay = Settings.System.getInt(mContext.getContentResolver(),
-                Settings.System.SCREENSHOT_DELAY, 100);
+                Settings.System.SCREENSHOT_DELAY, 600);
     }
 }

--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -8983,7 +8983,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
 
     private void checkSettings() {
         mScreenshotDelay = Settings.System.getInt(mContext.getContentResolver(),
-                Settings.System.SCREENSHOT_DELAY, 100);
+                Settings.System.SCREENSHOT_DELAY, 600);
     }
 
     public void freezeOrThawRotation(int rotation) {


### PR DESCRIPTION
 * In 150e91a060ea7ab3d4aba8d910b2c3e43c2b6b15, the screenshot delay was set to
 100ms. While this is fine for most use cases, it does not work well with the
 screenshot tile. When the screenshot delay is set to 100ms and a user takes a full
 screenshot with the QS tile, the notification shade does not move completely out of
 the way before the screenshot is taken. 600ms is the smallest amount of time required
 for the QS panel to move out of the way when using the screenshot tile.

Signed-off-by: Raleigh Matlock <raleighman2@gmail.com>